### PR TITLE
Add setup script for environment and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ It was developed with the help of AI tools (e.g., ChatGPT) and includes original
 - GUI with real-time feedback
 - Optional integration of MIDI and audio analysis
 
+## Getting Started
+
+1. Run `./setup_env.sh` to create a virtual environment and install Python
+   dependencies listed in `requirements.txt`.
+2. Activate the environment:
+   `source .venv/bin/activate`
+3. Launch the application with `python player.py`.
+
+The setup script reminds you to install system packages such as `ffmpeg` and
+`python3-tk` which are required for full functionality.
+
 ## AI Contribution Notice
 
 The code includes parts generated or assisted by AI. The unique value of the project resides in:

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Setup script for Player3
+# Creates a Python virtual environment and installs dependencies
+set -e
+
+python3 -m venv .venv
+
+# Activate the virtual environment
+source .venv/bin/activate
+
+# Upgrade pip and install dependencies
+python -m pip install --upgrade pip
+if [ -f requirements.txt ]; then
+    pip install -r requirements.txt
+fi
+
+echo "Reminder: system packages like 'ffmpeg' and 'python3-tk' may be required."


### PR DESCRIPTION
## Summary
- add `setup_env.sh` for creating a Python virtualenv
- document how to use it in a new Getting Started section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68414b8ece0083299edebcbdbe3d48d0