### PR TITLE
Refactor player utilities into separate modules

### DIFF
--- a/audio_utils.py
+++ b/audio_utils.py
@@ -1,0 +1,58 @@
+import os
+import subprocess
+import tempfile
+from typing import Optional, Tuple
+
+import numpy as np
+import librosa
+
+
+def _util_extract_audio_segment(
+    input_path: str,
+    output_path: Optional[str] = None,
+    *,
+    start_sec: Optional[float] = None,
+    duration_sec: Optional[float] = None,
+    audio_codec: str = "pcm_s16le",
+    sample_rate: int = 44100,
+    channels: int = 1,
+    overwrite: bool = True,
+    use_temp_file: bool = True,
+) -> Optional[str]:
+    """Extract an audio segment via ffmpeg."""
+    if output_path is None:
+        if use_temp_file:
+            with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+                output_path = tmp.name
+        else:
+            raise ValueError("output_path required if use_temp_file=False")
+
+    cmd = ["ffmpeg"]
+    if overwrite:
+        cmd.append("-y")
+    if start_sec is not None:
+        cmd += ["-ss", str(start_sec)]
+    if duration_sec is not None:
+        cmd += ["-t", str(duration_sec)]
+    cmd += ["-i", input_path, "-vn", "-acodec", audio_codec, "-ar", str(sample_rate), "-ac", str(channels), output_path]
+
+    try:
+        subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except Exception:
+        return None
+
+    if not os.path.exists(output_path) or os.path.getsize(output_path) == 0:
+        return None
+
+    return output_path
+
+
+def _util_get_tempo_and_beats_librosa(y: np.ndarray, sr: int) -> Tuple[float, np.ndarray]:
+    """Return tempo and beat frames from audio using librosa."""
+    if y is None or len(y) == 0:
+        return 0.0, np.array([])
+    try:
+        tempo, beats = librosa.beat.beat_track(y=y, sr=sr)
+        return float(tempo), beats
+    except Exception:
+        return 0.0, np.array([])

--- a/time_utils.py
+++ b/time_utils.py
@@ -1,0 +1,26 @@
+from datetime import timedelta
+
+
+def seconds_to_hms(seconds):
+    """Convert seconds to HH:MM:SS format."""
+    return str(timedelta(seconds=float(seconds))).split(".")[0]
+
+
+def format_time(seconds, include_ms=True, include_tenths=False):
+    """Format seconds as H:M:S with optional milliseconds or tenths."""
+    if seconds is None or seconds < 0:
+        if include_ms:
+            return "--:--:--.-" if include_tenths else "--:--:--.---"
+        return "--:--:--"
+
+    h = int(seconds // 3600)
+    m = int((seconds % 3600) // 60)
+    s = int(seconds % 60)
+
+    if include_ms:
+        if include_tenths:
+            tenths = int((seconds - int(seconds)) * 10)
+            return f"{h}:{m:02}:{s:02}.{tenths}"
+        ms = int(round((seconds - int(seconds)) * 1000))
+        return f"{h}:{m:02}:{s:02}.{ms:03}"
+    return f"{h}:{m:02}:{s:02}"

--- a/video_utils.py
+++ b/video_utils.py
@@ -1,0 +1,48 @@
+import subprocess
+from typing import List, Optional
+
+
+def extract_keyframes(
+    video_path: str,
+    start_time_sec: Optional[float] = None,
+    duration_sec: Optional[float] = None,
+    end_time_sec: Optional[float] = None,
+) -> List[float]:
+    """Extract keyframe timestamps from a video using ffprobe."""
+    cmd = [
+        "ffprobe",
+        "-v",
+        "error",
+        "-select_streams",
+        "v:0",
+        "-show_entries",
+        "frame=pkt_pts_time,pict_type",
+        "-of",
+        "csv=p=0",
+        video_path,
+    ]
+    try:
+        output = subprocess.check_output(cmd, stderr=subprocess.PIPE).decode()
+    except Exception:
+        return []
+    keyframes = []
+    for line in output.strip().splitlines():
+        try:
+            time_str, frame_type = line.split(",")
+        except ValueError:
+            continue
+        if frame_type.strip() == "I":
+            try:
+                t = float(time_str)
+            except ValueError:
+                continue
+            keyframes.append(t)
+
+    if start_time_sec is not None:
+        end = start_time_sec + duration_sec if duration_sec is not None else end_time_sec
+        if end is not None:
+            keyframes = [t for t in keyframes if start_time_sec <= t < end]
+        else:
+            keyframes = [t for t in keyframes if t >= start_time_sec]
+
+    return keyframes


### PR DESCRIPTION
## Summary
- extract timing helpers to `time_utils.py`
- move ffmpeg and tempo helpers to `audio_utils.py`
- create `video_utils.py` for keyframe extraction
- update `player.py` to import from these modules and make heavy deps optional

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68418569eff88329835489922821b5d4