### PR TITLE
Fix tap tempo binding location

### DIFF
--- a/player.py
+++ b/player.py
@@ -6520,6 +6520,7 @@ class VideoPlayer:
         # self.root.bind('<Key-r>', lambda e: self.toggle_loop())
         self.root.bind('<Shift-T>', lambda e: self.toggle_autostep())
         self.root.bind('<Key-t>', lambda e: self.step_play())
+        self.root.bind('t', lambda e: self.tap_tempo())
         self.root.bind('<Shift-A>', lambda e: self.record_loop_marker("loop_start", auto_exit=True))
         self.root.bind('<Shift-B>', lambda e: self.record_loop_marker("loop_end", auto_exit=True))
         self.root.bind("<Shift-C>", self.clear_loop)
@@ -7836,7 +7837,6 @@ class VideoPlayer:
         self.apply_crop() 
 
     def update_loop(self):
-        self.root.bind('t', lambda e: self.tap_tempo())
 
         if self.grid_visible:
             self.draw_rhythm_grid_canvas()


### PR DESCRIPTION
## Summary
- move binding for the 't' key from `update_loop` to the initialization
- avoid rebinding every loop iteration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ce60a6548329bc22f09bb2a7ebd5