### PR TITLE
Align imports with lib_switch

### DIFF
--- a/audio_utils.py
+++ b/audio_utils.py
@@ -3,7 +3,7 @@ import subprocess
 import tempfile
 from typing import Optional, Tuple
 
-from lib_switch import np, librosa
+from lib_switch import np, librosa, scipy, sf
 
 
 def _util_extract_audio_segment(

--- a/player.py
+++ b/player.py
@@ -802,7 +802,7 @@ def detect_tempo_and_beats(audio_path, loop_start=35.0, loop_end=75.0):
 # --- scanfile.py ---
 import tkinter as tk
 from tkinter import filedialog
-from lib_switch import np, librosa, scipy
+from lib_switch import np, librosa, scipy, sf
 try:
     import os
     import librosa.display
@@ -989,7 +989,7 @@ def open_vlc_at(filepath, seconds):
 import subprocess
 import tempfile
 import os
-from lib_switch import np, librosa
+from lib_switch import np, librosa, scipy, sf
 import subprocess
 try:
     import ffmpeg
@@ -1247,7 +1247,7 @@ except Exception:  # pragma: no cover - optional dependency
 import os
 
 import time
-from lib_switch import np, librosa, sf
+from lib_switch import np, librosa, scipy, sf
 try:
     from basic_pitch.inference import predict
     from basic_pitch import ICASSP_2022_MODEL_PATH
@@ -1280,7 +1280,7 @@ def hms_to_seconds(hms):
     return sum(t * 60**i for i, t in enumerate(reversed(parts)))
 
 
-from lib_switch import sf
+from lib_switch import np, librosa, scipy, sf
 
 import subprocess
 import os

--- a/test_player_utils.py
+++ b/test_player_utils.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import patch, mock_open, MagicMock
-from lib_switch import np
+from lib_switch import np, librosa, scipy, sf
 import os # For os.path.exists checks in _util_extract_audio_segment tests
 
 # Assuming player.py is in the same directory or accessible via PYTHONPATH


### PR DESCRIPTION
## Summary
- consolidate external library imports via `lib_switch`
- adjust tests to import `lib_switch` modules consistently

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842b0cde4788329b212d02cfd2e0a5c