### PR TITLE
Sync lib_switch and extend stubs

### DIFF
--- a/lib_switch.py
+++ b/lib_switch.py
@@ -7,22 +7,21 @@ if USE_REAL_LIBS:
     import numpy as np
     import librosa
     import scipy
-    import soundfile as soundfile
+    import soundfile as sf
 else:
     from stubs import numpy_stub as np
     from stubs import librosa
     from stubs import scipy
-    from stubs import soundfile
+    from stubs import soundfile as sf
 
 # Expose modules via sys.modules so regular imports work
 sys.modules.setdefault('numpy', np)
 sys.modules.setdefault('librosa', librosa)
 sys.modules.setdefault('scipy', scipy)
 sys.modules.setdefault('scipy.signal', scipy.signal)
-sys.modules.setdefault('soundfile', soundfile)
+sys.modules.setdefault('soundfile', sf)
 
-# Convenience alias
-sf = soundfile
+# Convenience alias remains 'sf'
 
 # numpy compatibility
 if not hasattr(np, 'complex'):

--- a/stubs/scipy/signal.py
+++ b/stubs/scipy/signal.py
@@ -3,3 +3,10 @@ def butter(*args, **kwargs):
 
 def sosfilt(sos, y):
     return y
+
+def find_peaks(x, height=None, distance=None):
+    """Simplified peak finding stub.
+
+    Parameters are ignored and an empty result is returned
+    for compatibility with real scipy.signal.find_peaks."""
+    return [], {}

--- a/stubs/soundfile.py
+++ b/stubs/soundfile.py
@@ -1,6 +1,9 @@
 from io import BytesIO
 
-def read(file, dtype='float32'):
+def read(file, dtype='float32', *, always_2d=False):
+    """Simplified soundfile.read stub.
+
+    Parameters are accepted for API compatibility but ignored."""
     return [], 22050
 
 def write(file, data, samplerate):


### PR DESCRIPTION
## Summary
- import `soundfile` as `sf` in `lib_switch`
- expose `sf` via `sys.modules`
- add a minimal `find_peaks` stub
- update soundfile stub to accept `always_2d`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842b0c1c53883299a38adfdcc898450