### PR TITLE
Handle None values in debug_grid_subdivs

### DIFF
--- a/player.py
+++ b/player.py
@@ -2296,7 +2296,11 @@ class VideoPlayer:
         caller = inspect.stack()[1].function
         Brint(f"[TRACE GRID] 🧩 Assigné par '{caller}' {f'→ {source}' if source else ''}")
 
-        if not hasattr(self, "loop_start") or not hasattr(self, "loop_end") or self.tempo_bpm is None:
+        if (
+            not hasattr(self, "loop_start") or self.loop_start is None or
+            not hasattr(self, "loop_end") or self.loop_end is None or
+            self.tempo_bpm is None
+        ):
             Brint("[TRACE GRID ERROR] ❌ loop_start, loop_end ou tempo_bpm manquant — grille non générée")
             self.grid_subdivs = []
             return


### PR DESCRIPTION
## Summary
- guard against None loop boundaries in `debug_grid_subdivs`
- retain graceful behaviour in `compute_rhythm_grid_infos`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684303355a948329a51d48f1a5e776bd