### PR TITLE
Remove early return that hid playhead when paused

### DIFF
--- a/player.py
+++ b/player.py
@@ -6890,8 +6890,7 @@ class VideoPlayer:
         else:
             current_time_ms = self.playhead_time * 1000
 
-        if not self.player.is_playing():
-            return
+
 
         self.update_count += 1
         if not self.duration or self.duration <= 0:


### PR DESCRIPTION
## Summary
- ensure `update_playhead_by_time` always draws the playhead

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684307319e2c832994855f6610e243f6