### PR TITLE
Fix playhead refresh when media length not yet known

### DIFF
--- a/player.py
+++ b/player.py
@@ -6894,7 +6894,12 @@ class VideoPlayer:
 
         self.update_count += 1
         if not self.duration or self.duration <= 0:
-            return
+            # Try to fetch the duration again in case VLC hadn't returned it yet
+            dur = self.player.get_length() if hasattr(self, "player") else 0
+            if dur and dur > 0:
+                self.duration = dur
+            else:
+                return
 
         if self.cached_width is None or time.time() - self.last_width_update > 1:
             self.cached_width = self.timeline.winfo_width()


### PR DESCRIPTION
## Summary
- when the player starts some media the duration can be `0`
- `update_playhead_by_time` now retries to fetch duration from VLC before returning

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684315624b70832989d9a01706bda9f8