### PR TITLE
Fix count-in detection with empty onset

### DIFF
--- a/player.py
+++ b/player.py
@@ -839,7 +839,12 @@ def detect_countins_with_rms(filepath, hop_length=256, strict=False, mode="defau
     rms = librosa.feature.rms(y=y, frame_length=1024, hop_length=hop_length)[0]
     rms_times = librosa.frames_to_time(np.arange(len(rms)), sr=sr, hop_length=hop_length)
 
-    peaks, _ = find_peaks(onset_env, height=0.2 * np.max(onset_env), distance=int(0.4 * sr / hop_length))
+    if len(onset_env) == 0:
+        Brint("[WARNING] detect_countins_with_rms - empty onset_env")
+        return []
+
+    peak_height = 0.2 * np.max(onset_env)
+    peaks, _ = find_peaks(onset_env, height=peak_height, distance=int(0.4 * sr / hop_length))
     click_times = onset_times[peaks]
 
 

--- a/test_player_utils.py
+++ b/test_player_utils.py
@@ -10,6 +10,7 @@ from player import (
     _util_get_tempo_and_beats_librosa,
     extract_keyframes,
     VideoPlayer,
+    detect_countins_with_rms,
 )
 
 class TestFormatTime(unittest.TestCase):
@@ -276,6 +277,16 @@ class TestBuildRhythmGrid(unittest.TestCase):
         VideoPlayer.build_rhythm_grid(d)
         self.assertEqual(d.grid_labels, ["da", "da"])
         self.assertEqual(len(d.grid_times), 2)
+
+
+class TestDetectCountinsWithRms(unittest.TestCase):
+    @patch('player.find_peaks')
+    @patch('player.librosa.load')
+    def test_empty_audio_returns_empty_list(self, mock_load, mock_find_peaks):
+        mock_load.return_value = ([], 22050)
+        result = detect_countins_with_rms('dummy.wav', verbose=False)
+        self.assertEqual(result, [])
+        mock_find_peaks.assert_not_called()
 
 if __name__ == '__main__':
     unittest.main(argv=['first-arg-is-ignored'], exit=False)


### PR DESCRIPTION
## Summary
- handle empty `onset_env` in `detect_countins_with_rms`
- add unit test for empty audio input

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68432a5deb64832983f1e4f3a44e90bd