### PR TITLE
Allow playhead drawing before duration known

### DIFF
--- a/player.py
+++ b/player.py
@@ -6919,7 +6919,8 @@ class VideoPlayer:
             if dur and dur > 0:
                 self.duration = dur
             else:
-                return
+                # Duration still unknown – continue drawing using fallbacks
+                Brint("[PH WARN] duration not yet available; drawing with fallback values")
 
         if self.cached_width is None or time.time() - self.last_width_update > 1:
             self.cached_width = self.timeline.winfo_width()


### PR DESCRIPTION
## Summary
- log a warning when duration isn't yet known instead of exiting early
- rely on fallback zoom logic so the playhead can be drawn immediately

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68432a488de48329a87610575cb485ef