### PR TITLE
Update time_sec_to_canvas_x zoom handling

### DIFF
--- a/player.py
+++ b/player.py
@@ -2534,7 +2534,7 @@ class VideoPlayer:
             self.loop_zoom_ratio = 1.0
             Brint(f"[INFO Time2X] Pas de loop active, fallback à toute la durée ({loop_end} ms) avec zoom_ratio=1.0")
 
-        loop_width = loop_end - loop_start
+        loop_range = loop_end - loop_start
         zoom = self.get_zoom_context()
         zoom_start = zoom["zoom_start"]
         zoom_range = zoom["zoom_range"]
@@ -2548,7 +2548,15 @@ class VideoPlayer:
             print(f"[WARNING] zoom_range invalide ({zoom_range}), fallback 1000")
             zoom_range = 1000
 
-        x = round((t_ms - zoom_start) / zoom_range * canvas_width)
+        ratio = (t_ms - zoom_start) / zoom_range
+        if zoom_range < loop_range:
+            x = 0.2 * canvas_width + ratio * 0.6 * canvas_width
+        else:
+            x = ratio * canvas_width
+
+        x = max(0, min(canvas_width, x))
+        print(t_sec, zoom_range, loop_range, ratio, x)
+        x = round(x)
 
         Brint(f"[DEBUG time_sec_to_canvas_x] t_sec={t_sec:.3f}s | t_ms={t_ms:.1f} | zoom_start={zoom_start} | zoom_range={zoom_range} | canvas_width={canvas_width} → x={x}")
         return x


### PR DESCRIPTION
## Summary
- refine mapping logic in `time_sec_to_canvas_x`
- clamp result and debug print for easier diagnostics

## Testing
- `pytest -q` *(fails: cannot import name 'VisibleDeprecationWarning' from stub numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6843fee2cf3c83299a443e00c9f6a7f3