### PR TITLE
Support loop-internal zoom

### DIFF
--- a/ph_test.py
+++ b/ph_test.py
@@ -6,12 +6,37 @@ from stubs import numpy_stub as np
 from stubs import librosa
 from stubs import scipy
 from stubs import soundfile as sf
+import types
 
 sys.modules['numpy'] = np
+sys.modules['numpy.linalg'] = np.linalg
 sys.modules['librosa'] = librosa
+sys.modules['librosa.display'] = types.ModuleType('librosa.display')
 sys.modules['scipy'] = scipy
-sys.modules['scipy.signal'] = scipy.signal
+scipy_signal = types.ModuleType('scipy.signal')
+scipy_signal.find_peaks = lambda *a, **k: ([], {})
+scipy_signal.butter = lambda *a, **k: []
+scipy_signal.sosfilt = lambda sos, y: y
+sys.modules['scipy.signal'] = scipy_signal
 sys.modules['soundfile'] = sf
+
+mpl = types.ModuleType('matplotlib')
+pyplot = types.ModuleType('matplotlib.pyplot')
+pyplot.plot = lambda *a, **k: None
+pyplot.subplots = lambda *a, **k: (None, None)
+sys.modules['matplotlib'] = mpl
+sys.modules['matplotlib.pyplot'] = pyplot
+sys.modules['matplotlib.patches'] = types.ModuleType('matplotlib.patches')
+sys.modules['matplotlib.gridspec'] = types.ModuleType('matplotlib.gridspec')
+sys.modules['matplotlib.animation'] = types.ModuleType('matplotlib.animation')
+sys.modules['pygame'] = types.ModuleType('pygame')
+pygame_mixer = types.ModuleType('pygame.mixer')
+pygame_mixer.get_init = lambda: False
+pygame_mixer.quit = lambda: None
+pygame_mixer.music = type('music', (), {'stop': lambda: None, 'load': lambda x: None})()
+sys.modules['pygame.mixer'] = pygame_mixer
+sys.modules['pydub'] = types.ModuleType('pydub')
+sys.modules['pydub'].AudioSegment = type('AudioSegment', (), {'from_file': lambda *a, **k: None})
 
 # Désactive forçage des vraies libs
 os.environ['PLAYER_USE_REAL_LIBS'] = '0'
@@ -43,7 +68,11 @@ class DummyPlayer(player.VideoPlayer):
     def __init__(self):
         self.timeline = DummyCanvas()
         self.root = DummyRoot()
-        self.player = type("P", (), {"get_length": lambda self: 10000})()
+        self.player = type("P", (), {
+            "get_length": lambda self: 10000,
+            "is_playing": lambda self: True,
+            "get_time": lambda self: 0,
+        })()
         self.duration = 10000  # 10 secondes
         self.cached_width = 300
         self.last_width_update = time.time()

--- a/player.py
+++ b/player.py
@@ -3339,9 +3339,12 @@ class VideoPlayer:
         Brint(f"[ZOOM] 🔍 Zoom boucle réglé sur {self.loop_zoom_ratio:.2f} (AB = {int(self.loop_zoom_ratio*100)}% de la timeline)")
 
         if self.loop_start is not None and self.loop_end is not None and self.duration:
-            loop_width_ms = max(10000.0, self.loop_end - self.loop_start)
+            loop_width_ms = max(4000.0, self.loop_end - self.loop_start)
             center_ms = (self.loop_start + self.loop_end) / 2.0
             desired_ms = loop_width_ms / self.loop_zoom_ratio
+            if self.loop_zoom_ratio > 1.0:
+                desired_ms = max(4000.0, desired_ms)
+                desired_ms = min(desired_ms, loop_width_ms)
             zoom_start = max(0.0, center_ms - desired_ms / 2.0)
             zoom_end = min(self.duration, zoom_start + desired_ms)
             self.zoom_context = {
@@ -3358,9 +3361,12 @@ class VideoPlayer:
 
     def get_loop_zoom_range(self):
         if self.loop_start and self.loop_end:
-            loop_width_sec = max(10.0, (self.loop_end - self.loop_start) / 1000.0)
+            loop_width_sec = max(4.0, (self.loop_end - self.loop_start) / 1000.0)
             center_sec = (self.loop_start + self.loop_end) / 2000.0
             desired_sec = loop_width_sec / self.loop_zoom_ratio
+            if self.loop_zoom_ratio > 1.0:
+                desired_sec = max(4.0, desired_sec)
+                desired_sec = min(desired_sec, loop_width_sec)
             zoom_start = max(0, center_sec - desired_sec / 2.0)
             zoom_end = min(self.duration / 1000.0, center_sec + desired_sec / 2.0)
             return zoom_start, zoom_end
@@ -6521,7 +6527,7 @@ class VideoPlayer:
         # === RHYTHM CONTROLS FRAME ===
         self.rhythm_controls_frame = Frame(self.controls_top)
         self.rhythm_controls_frame.pack(side='left', padx=5)
-        self.zoom_slider = Scale(self.rhythm_controls_frame, from_=0.1, to=1.0, resolution=0.05, orient='horizontal', label='ZoomAB', showvalue=False,  length=60, sliderlength=10, width=8, font=("Arial", 6), command=self.on_loop_zoom_change)
+        self.zoom_slider = Scale(self.rhythm_controls_frame, from_=0.1, to=3.0, resolution=0.05, orient='horizontal', label='ZoomAB', showvalue=False,  length=60, sliderlength=10, width=8, font=("Arial", 6), command=self.on_loop_zoom_change)
         self.zoom_slider.bind("<Double-Button-1>", lambda e: self.reset_zoom_slider())
         self.zoom_slider.set(self.loop_zoom_ratio)
         self.zoom_slider.pack(side='left', padx=5)

--- a/stubs/numpy_stub.py
+++ b/stubs/numpy_stub.py
@@ -11,6 +11,8 @@ class ndarray(list):
     pass
 
 float32 = float
+uint8 = int
+inf = float('inf')
 
 
 def array(obj):
@@ -54,6 +56,11 @@ def abs(x):
 def where(condition):
     return ([i for i, v in enumerate(condition) if v],)
 
+def vectorize(func):
+    def wrapper(seq):
+        return [func(x) for x in seq]
+    return wrapper
+
 class RandomModule:
     def rand(self, n):
         return [_random.random() for _ in range(int(n))]
@@ -67,4 +74,15 @@ class TestingModule:
 
 class testing:
     assert_array_equal = staticmethod(TestingModule.assert_array_equal)
+
+
+# Added for compatibility with libraries expecting numpy's warning classes
+class VisibleDeprecationWarning(Warning):
+    pass
+
+
+class linalg:
+    @staticmethod
+    def inv(x):
+        return x
 


### PR DESCRIPTION
## Summary
- extend `ZoomAB` slider range to 3.0
- allow zoom ranges smaller than the loop down to 4s
- patch numpy stub with minimal attributes used by matplotlib
- update `ph_test.py` with stubs for additional dependencies and improved dummy player

## Testing
- `python ph_test.py`

------
https://chatgpt.com/codex/tasks/task_e_684403b3a52c8329a3f81ae3ae079aa6