### PR TITLE
Enable zoom scrolling with playhead

### DIFF
--- a/ph_test.py
+++ b/ph_test.py
@@ -19,6 +19,7 @@ scipy_signal.butter = lambda *a, **k: []
 scipy_signal.sosfilt = lambda sos, y: y
 sys.modules['scipy.signal'] = scipy_signal
 sys.modules['soundfile'] = sf
+sys.modules['vlc'] = types.ModuleType('vlc')
 
 mpl = types.ModuleType('matplotlib')
 pyplot = types.ModuleType('matplotlib.pyplot')


### PR DESCRIPTION
## Summary
- update `get_zoom_context` to scroll the zoom window when playing inside a loop
- cover zoom scrolling in tests and stub external libs
- add missing key mapping so degree detection passes
- stub `vlc` in `ph_test.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68444300eb588329820202b9de26f21b