### PR TITLE
Fix timeline markers visibility

### DIFF
--- a/player.py
+++ b/player.py
@@ -2576,7 +2576,8 @@ class VideoPlayer:
         else:
             x = ratio * canvas_width
 
-        x = max(0, min(canvas_width, x))
+        # The raw canvas position may lie outside the visible range when zoomed.
+        # Return this unclamped value so callers can decide how to handle it.
         print(t_sec, zoom_range, loop_range, ratio, x)
         x = round(x)
 
@@ -7099,12 +7100,12 @@ class VideoPlayer:
             self.timeline.create_text(x_label, 6, text=loop["name"], anchor='w', fill="cyan", tags=tags)
             self.timeline.tag_bind(tag, "<Button-1>", lambda e, i=idx: self.load_saved_loop(i))
 
-        if self.loop_start:
+        if self.loop_start and zoom_start <= self.loop_start <= zoom_end:
             xa = self.time_sec_to_canvas_x(self.loop_start / 1000)
             self.timeline.create_line(xa, 0, xa, 24, fill="green", tags="loop_marker")
             self.timeline.create_text(xa + 10, 18, text=f"A: {self.hms(self.loop_start)}", anchor='w', fill="white", tags="loop_marker")
 
-        if self.loop_end:
+        if self.loop_end and zoom_start <= self.loop_end <= zoom_end:
             xb = self.time_sec_to_canvas_x(self.loop_end / 1000)
             self.timeline.create_line(xb, 0, xb, 24, fill="orange", tags="loop_marker")
             self.timeline.create_text(xb + 10, 18, text=f"B: {self.hms(self.loop_end)}", anchor='w', fill="white", tags="loop_marker")


### PR DESCRIPTION
## Summary
- allow `time_sec_to_canvas_x` to return unclamped canvas positions
- draw loop markers only when A/B points are visible in the zoomed range

## Testing
- `python -m pytest -q`
- `python ph_test.py`

------
https://chatgpt.com/codex/tasks/task_e_6844499703508329b4751abfba3378e9