### PR TITLE
Fix rhythmic grid offset when scrolling zoomed loop

### DIFF
--- a/player.py
+++ b/player.py
@@ -2850,10 +2850,7 @@ class VideoPlayer:
         playhead_x = getattr(self, 'playhead_canvas_x', -9999)
 
         for idx, (i, t_subdiv_sec) in enumerate(self.grid_subdivs):
-            subdiv_duration_s = 60.0 / self.tempo_bpm / subdivisions_per_beat
-            pixels_per_subdiv = 1000 * subdiv_duration_s * canvas_width / zoom_range
-            x_loop_start = self.time_sec_to_canvas_x(self.loop_start / 1000.0)
-            x = x_loop_start + idx * pixels_per_subdiv
+            x = self.time_sec_to_canvas_x(t_subdiv_sec)
 
             state = self.subdivision_state.get(i, 0)
             is_playhead = abs(x - playhead_x) < 1
@@ -8482,14 +8479,7 @@ class VideoPlayer:
             if count == 0:
                 continue  # On ne dessine que si frappes
 
-            # x_pos = self.time_sec_to_canvas_x(t_subdiv_sec )
-            subdiv_duration_s = 60.0 / self.tempo_bpm / self.get_subdivisions_per_beat()
-            canvas_width = self.grid_canvas.winfo_width()
-            zoom = self.get_zoom_context()
-            zoom_range = zoom["zoom_range"]
-            pixels_per_subdiv = 1000 * subdiv_duration_s * canvas_width / zoom_range
-            x_loop_start = self.time_sec_to_canvas_x(self.loop_start / 1000.0)
-            x_pos = x_loop_start + i * pixels_per_subdiv
+            x_pos = self.time_sec_to_canvas_x(t_subdiv_sec)
             label = self.grid_labels[i] if i < len(self.grid_labels) else "?"
             color = "#FF0000" if count > 3 else "#FF8800"
             width = 4 + count * 2

--- a/test_player_utils.py
+++ b/test_player_utils.py
@@ -367,5 +367,28 @@ class TestTogglePauseLoopTiming(unittest.TestCase):
         vp.player.play.assert_called_once()
         vp.update_loop.assert_called_once()
 
+
+class TestGridZoomScaling(unittest.TestCase):
+    class Dummy(VideoPlayer):
+        def __init__(self):
+            self.loop_start = 0
+            self.loop_end = 8000
+            self.tempo_bpm = 60
+            self.subdivision_mode = "binary4"
+            self.grid_canvas = MagicMock()
+            self.grid_canvas.winfo_width.return_value = 1000
+            self.player = MagicMock()
+            self.player.get_length.return_value = 8000
+            self.loop_zoom_ratio = 2.0
+            self.zoom_context = {"zoom_start": 0, "zoom_end": 4000, "zoom_range": 4000}
+            self.subdivision_state = {}
+
+    def test_subdivision_positions_scaled_with_zoom(self):
+        d = self.Dummy()
+        VideoPlayer.build_rhythm_grid(d)
+        infos = d.compute_rhythm_grid_infos()
+        self.assertAlmostEqual(infos[0]["x"], 200)
+        self.assertAlmostEqual(infos[1]["x"], 350)
+
 if __name__ == '__main__':
     unittest.main(argv=['first-arg-is-ignored'], exit=False)


### PR DESCRIPTION
## Summary
- fix grid position calculations to use `time_sec_to_canvas_x`
- update heatmap drawing accordingly
- add regression test for zoomed grid scaling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844649cc9f08329839a0f97dd9759cf