### PR TITLE
Add spawn_new_instance option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ It was developed with the help of AI tools (e.g., ChatGPT) and includes original
 3. Launch the application with `python player.py`.
    You can optionally pass a number to load a recent file by index or a full
    file path to open that media directly.
+   The `open_file()` and `open_given_file()` methods also accept a
+   `spawn_new_instance` flag. When set to `True` the current player spawns
+   `python player.py <path>` in a new process and then exits.
 
 The setup script reminds you to install system packages such as `ffmpeg` and
 `python3-tk` which are required for full functionality.

--- a/player.py
+++ b/player.py
@@ -5124,8 +5124,14 @@ class VideoPlayer:
         Brint(f"✅ Script {os.path.basename(script_path)} uploadé comme {target_name}")
         self.log_to_console(f"✅ Script {os.path.basename(script_path)} uploadé comme {target_name}")
 
-    def open_given_file(self, path):
+    def open_given_file(self, path, spawn_new_instance=False):
         """Charge un fichier donné directement, sans repasser par le file dialog."""
+        if spawn_new_instance:
+            import subprocess, sys, os
+            subprocess.Popen([sys.executable, os.path.abspath(__file__), path])
+            self.root.destroy()
+            sys.exit(0)
+            return
         self.current_path = path
         self.root.after(1000, self.load_screen_zoom_prefs)
 
@@ -7892,12 +7898,18 @@ class VideoPlayer:
 
  
  
-    def open_file(self):
+    def open_file(self, spawn_new_instance=False):
         self.needs_refresh = True
         self.refresh_static_timeline_elements()
 
         path = filedialog.askopenfilename()
         if not path:
+            return
+        if spawn_new_instance:
+            import subprocess, sys, os
+            subprocess.Popen([sys.executable, os.path.abspath(__file__), path])
+            self.root.destroy()
+            sys.exit(0)
             return
         self.current_path = path
         self.root.after(1000, self.load_screen_zoom_prefs)

--- a/test_player_utils.py
+++ b/test_player_utils.py
@@ -25,6 +25,7 @@ from player import (
     extract_keyframes,
     VideoPlayer,
 )
+import player
 
 class TestFormatTime(unittest.TestCase):
     def test_zero_seconds(self):
@@ -389,6 +390,19 @@ class TestGridZoomScaling(unittest.TestCase):
         infos = d.compute_rhythm_grid_infos()
         self.assertAlmostEqual(infos[0]["x"], 200)
         self.assertAlmostEqual(infos[1]["x"], 350)
+
+
+class TestSpawnNewInstance(unittest.TestCase):
+    @patch('player.subprocess.Popen')
+    @patch('player.sys.exit')
+    def test_open_given_file_spawns(self, mock_exit, mock_popen):
+        vp = VideoPlayer.__new__(VideoPlayer)
+        vp.root = MagicMock()
+        VideoPlayer.open_given_file(vp, 'sample.mp4', spawn_new_instance=True)
+        expected = [sys.executable, os.path.abspath(player.__file__), 'sample.mp4']
+        mock_popen.assert_called_once_with(expected)
+        vp.root.destroy.assert_called_once()
+        mock_exit.assert_called_once_with(0)
 
 if __name__ == '__main__':
     unittest.main(argv=['first-arg-is-ignored'], exit=False)


### PR DESCRIPTION
## Summary
- add an optional `spawn_new_instance` parameter to `open_file` and `open_given_file`
- allow spawning a new player process and exiting
- document the option in the README
- test that new process creation uses the correct arguments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844793829908329b073bdd508468600