### PR TITLE
Update zoom scroll behavior

### DIFF
--- a/player.py
+++ b/player.py
@@ -2386,7 +2386,7 @@ class VideoPlayer:
             base_zoom is not None
             and self.loop_start is not None
             and self.loop_end is not None
-            and base_zoom.get("zoom_range", 0) < (self.loop_end - self.loop_start)
+            and base_zoom.get("zoom_range", 0) < (self.loop_end - self.loop_start) / 0.9
             and getattr(self, "playhead_time", None) is not None
         ):
             playhead_ms = self.playhead_time * 1000.0
@@ -2577,7 +2577,7 @@ class VideoPlayer:
 
         ratio = (t_ms - zoom_start) / zoom_range
         if zoom_range < loop_range:
-            x = 0.2 * canvas_width + ratio * 0.6 * canvas_width
+            x = 0.05 * canvas_width + ratio * 0.90 * canvas_width
         else:
             x = ratio * canvas_width
 

--- a/test_player_utils.py
+++ b/test_player_utils.py
@@ -388,8 +388,8 @@ class TestGridZoomScaling(unittest.TestCase):
         d = self.Dummy()
         VideoPlayer.build_rhythm_grid(d)
         infos = d.compute_rhythm_grid_infos()
-        self.assertAlmostEqual(infos[0]["x"], 200)
-        self.assertAlmostEqual(infos[1]["x"], 350)
+        self.assertAlmostEqual(infos[0]["x"], 50)
+        self.assertAlmostEqual(infos[1]["x"], 275)
 
 
 class TestSpawnNewInstance(unittest.TestCase):


### PR DESCRIPTION
## Summary
- adjust threshold for zoom scroll to start when zoom range is under 111% of loop
- map playhead movement from 5% to 95% of canvas width
- update tests for new zoom mapping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68449c37adf88329a582cb89b072ac61