### PR TITLE
Fix debug flags window

### DIFF
--- a/player.py
+++ b/player.py
@@ -3391,7 +3391,7 @@ class VideoPlayer:
 
     def open_debug_flags_window(self):
         """Open a window with checkboxes to toggle DEBUG_FLAGS."""
-        if hasattr(self, 'debug_window') and self.debug_window.winfo_exists():
+        if getattr(self, 'debug_window', None) and self.debug_window.winfo_exists():
             self.debug_window.lift()
             return
 


### PR DESCRIPTION
## Summary
- avoid AttributeError when opening debug flags window

## Testing
- `python ph_test.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845547eb4e083299756fb8e91ad59d4