### PR TITLE
Implement compute_scroll_speed util

### DIFF
--- a/test_player_utils.py
+++ b/test_player_utils.py
@@ -439,5 +439,13 @@ class TestOpenFileAfterCancel(unittest.TestCase):
         vp.root.after_cancel.assert_called_once_with('cb1')
         self.assertIsNone(vp.after_id)
 
+
+class TestComputeScrollSpeed(unittest.TestCase):
+    def test_basic_speed(self):
+        from time_utils import compute_scroll_speed
+        speed = compute_scroll_speed(10.0, 5.0, 1000)
+        self.assertAlmostEqual(speed, 110.0)
+
 if __name__ == '__main__':
     unittest.main(argv=['first-arg-is-ignored'], exit=False)
+

--- a/time_utils.py
+++ b/time_utils.py
@@ -24,3 +24,12 @@ def format_time(seconds, include_ms=True, include_tenths=False):
         ms = int(round((seconds - int(seconds)) * 1000))
         return f"{h}:{m:02}:{s:02}.{ms:03}"
     return f"{h}:{m:02}:{s:02}"
+
+
+def compute_scroll_speed(T_loop, T_zoom, canvas_width):
+    """Return scroll speed (px/s) for static elements during dynamic zoom."""
+    if T_loop <= 0 or T_zoom <= 0 or canvas_width <= 0:
+        return 0.0
+    v_frac = (T_loop - 0.9 * T_zoom) / (T_loop * T_zoom)
+    return v_frac * canvas_width
+


### PR DESCRIPTION
## Summary
- add `compute_scroll_speed` utility in `time_utils`
- add unit test for `compute_scroll_speed`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845859d487c8329b8912f384776d47c