### PR TITLE
Swap F4 and F8 shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ main shortcuts and what they do:
 | `.` | Reset syllabic grid hits |
 | `Shift+F1` | Cycle subdivision mode backward |
 | `Shift+F2` | Cycle subdivision mode forward |
-| `F4` | Open chord editor for the whole loop |
+| `F4` | Toggle state window |
 | `F1` | Cycle syllable set backward |
 | `F2` | Cycle syllable set forward |
 | `F3` | Open debug flags window |
-| `F8` | Toggle state window |
+| `F8` | Open chord editor for the whole loop |
 | `F9` | Dump playhead debug log |
 | `F10` | Start 5 s profiling capture |
 | `Space` | Play/Pause |

--- a/player.py
+++ b/player.py
@@ -6753,13 +6753,13 @@ class VideoPlayer:
         self.root.bind("<Shift-F2>", lambda e: self.cycle_subdivision_mode())
         self.loop_menu_button.bind("<Button-1>", lambda e: self.update_loop_menu())
         # self.root.bind("<F4>", self.edit_current_chord_from_playhead)
-        self.root.bind("<F4>", lambda e: self.open_chord_editor_all())
+        self.root.bind("<F4>", self.toggle_state_window)
         self.root.bind("<F1>", lambda e: self.cycle_syllable_set_backward())
         self.root.bind("<F2>", lambda e: self.cycle_syllable_set())
         self.root.bind("<F3>", lambda e: self.open_debug_flags_window())
         
         self.root.bind("<F10>", self.start_profiling_5s)
-        self.root.bind("<F8>", self.toggle_state_window)
+        self.root.bind("<F8>", lambda e: self.open_chord_editor_all())
         # self.root.bind("<F9>", self.dump_playhead_debug_log())
 
         self.root.bind('<F9>', lambda e: self.dump_playhead_debug_log())


### PR DESCRIPTION
## Summary
- swap keyboard bindings so F4 toggles the state window and F8 opens the chord editor
- document the new shortcuts in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684554b0219c8329bbb04e7be098f501