### PR TITLE
Fix debug_grid_subdivs when loop not initialized

### DIFF
--- a/player.py
+++ b/player.py
@@ -2447,7 +2447,9 @@ class VideoPlayer:
         caller = inspect.stack()[1].function
         Brint(f"[TRACE GRID] 🧩 Assigné par '{caller}' {f'→ {source}' if source else ''}")
 
-        if not hasattr(self, "loop_start") or not hasattr(self, "loop_end") or self.tempo_bpm is None:
+        if (not hasattr(self, "loop_start") or self.loop_start is None or
+            not hasattr(self, "loop_end") or self.loop_end is None or
+            self.tempo_bpm is None):
             Brint("[TRACE GRID ERROR] ❌ loop_start, loop_end ou tempo_bpm manquant — grille non générée")
             self.grid_subdivs = []
             return


### PR DESCRIPTION
## Summary
- avoid NoneType error in `debug_grid_subdivs`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68458ae84f148329b51dce12de9beb27