### PR TITLE
Fix Tk variable retrieval crash

### DIFF
--- a/player.py
+++ b/player.py
@@ -8200,7 +8200,13 @@ class VideoPlayer:
         if self.pause_each_update.get():
             self.is_paused = True
         if not self.is_paused:
-            delay = int(self.update_delay_ms_var.get())
+            try:
+                delay = int(self.update_delay_ms_var.get())
+                if delay < 1:
+                    delay = 1
+            except Exception:
+                delay = 30
+                self.update_delay_ms_var.set(delay)
             self.after_id = self.root.after(delay, self.update_loop)
 
 


### PR DESCRIPTION
## Summary
- guard update loop delay parsing to avoid Tkinter IntVar errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68458b2178ec8329a7dcd1982bc65092