### PR TITLE
Handle interpolation around loop jumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Once the zoom goes beyond that threshold, we enter dynamic scroll mode:
 	•	Instead, the playhead position on the canvas is interpolated:
 	•	At the start (when the playhead is at A), it’s shown at 5% of the canvas width.
 	•	At the end (when the playhead reaches B), it’s at 95%.
+        •       Interpolation pauses during the B→A jump and resumes once playback restarts.
 	•	This creates a smooth visual scroll.
 	•	The actual zoom window length is fixed or clamped to a minimum duration (e.g., 4 seconds), which is smaller than the loop duration.
 

--- a/player.py
+++ b/player.py
@@ -8149,7 +8149,11 @@ class VideoPlayer:
                     self.last_loop_jump_time = time.perf_counter()
                     Brint(f"[INIT LOOP] loop_duration_s = {self.loop_duration_s:.3f}s")
 
-                if self.interp_var.get():
+                if self.freeze_interpolation:
+                    self.safe_update_playhead(player_now, source="VLC loop raw")
+                    if abs(player_now - self.loop_start) <= 30 and is_playing:
+                        self.freeze_interpolation = False
+                elif self.interp_var.get():
                     elapsed_since_last_jump = time.perf_counter() - self.last_loop_jump_time
                     loop_duration_corrected = self.loop_duration_s / player_rate
                     wrapped_elapsed = elapsed_since_last_jump % loop_duration_corrected
@@ -8159,6 +8163,7 @@ class VideoPlayer:
 
                     if elapsed_since_last_jump >= loop_duration_corrected:
                         self.safe_jump_to_time(self.loop_start, source="Jump B estim (all rates)")
+                        self.freeze_interpolation = True
                         self.last_loop_jump_time = time.perf_counter()
                         self.loop_pass_count += 1
                         Brint(f"[LOOP PASS] Boucle AB passée {self.loop_pass_count} fois")
@@ -8176,6 +8181,7 @@ class VideoPlayer:
                     self.safe_update_playhead(player_now, source="VLC loop raw")
                     if player_now >= self.loop_end:
                         self.safe_jump_to_time(self.loop_start, source="Jump B raw")
+                        self.freeze_interpolation = True
                         self.last_loop_jump_time = time.perf_counter()
                         self.loop_pass_count += 1
                         Brint(f"[LOOP PASS] Boucle AB passée {self.loop_pass_count} fois (raw)")


### PR DESCRIPTION
## Summary
- pause playhead interpolation whenever the loop jumps from B to A
- restore interpolation once playback resumes at A
- document this behavior in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845961a18b0832992151e516f24170d