### PR TITLE
Fix infinite recursion in auto zoom

### DIFF
--- a/player.py
+++ b/player.py
@@ -2194,7 +2194,8 @@ class VideoPlayer:
             Brint(f"[AUTOZOOM] 🎚️ zoom_slider.set({self.loop_zoom_ratio:.3f})")
             self.zoom_slider.set(self.loop_zoom_ratio)
 
-        self.update_loop()
+        if force:
+            self.update_loop()
      
 
  


### PR DESCRIPTION
## Summary
- avoid calling `update_loop` recursively in `auto_zoom_on_loop_markers`
- keep existing behavior when forced

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845997df4148329b239b8080bf1c957