### PR TITLE
Fix scroll speed clamp

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,5 +45,7 @@ def compute_scroll_speed(T_loop, T_zoom, canvas_width):
         v_scroll_px = v_scroll * canvas_width
     """
     v_frac = (T_loop - 0.9 * T_zoom) / (T_loop * T_zoom)
+    if v_frac < 0:
+        return 0.0  # Pas de scroll si la fenêtre couvre toute la boucle
     v_px_per_s = v_frac * canvas_width
     return v_px_per_s

--- a/test_player_utils.py
+++ b/test_player_utils.py
@@ -461,6 +461,12 @@ class TestComputeScrollSpeed(unittest.TestCase):
         speed = compute_scroll_speed(10.0, 5.0, 1000)
         self.assertAlmostEqual(speed, 110.0)
 
+    def test_no_scroll_when_zoom_large(self):
+        from time_utils import compute_scroll_speed
+        # Zoom window larger than the loop should not yield negative speed
+        speed = compute_scroll_speed(10.0, 12.0, 1000)
+        self.assertEqual(speed, 0.0)
+
 
 if __name__ == '__main__':
     unittest.main(argv=['first-arg-is-ignored'], exit=False)

--- a/time_utils.py
+++ b/time_utils.py
@@ -27,9 +27,22 @@ def format_time(seconds, include_ms=True, include_tenths=False):
 
 
 def compute_scroll_speed(T_loop, T_zoom, canvas_width):
-    """Return scroll speed (px/s) for static elements during dynamic zoom."""
+    """Return scroll speed (px/s) for static elements during dynamic zoom.
+
+    The speed should be positive when the zoom window is smaller than the loop
+    duration (dynamic scroll mode) and zero otherwise.  In particular when the
+    zoom range is wide enough that both A and B markers are visible, the scroll
+    speed must be ``0`` so elements remain static.
+    """
     if T_loop <= 0 or T_zoom <= 0 or canvas_width <= 0:
         return 0.0
+
     v_frac = (T_loop - 0.9 * T_zoom) / (T_loop * T_zoom)
+
+    # Clamp negative speed to 0 to avoid scrolling in the wrong direction when
+    # the zoom window is wider than the loop duration.
+    if v_frac < 0:
+        return 0.0
+
     return v_frac * canvas_width
 


### PR DESCRIPTION
## Summary
- handle negative values in `compute_scroll_speed`
- document the clamp in `AGENTS.md`
- test that scroll speed is zero when the zoom covers the whole loop

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68459ad8b3ac832995124992e69728f0