### PR TITLE
Fix scroll speed clamp

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,5 +45,12 @@ def compute_scroll_speed(T_loop, T_zoom, canvas_width):
         v_scroll_px = v_scroll * canvas_width
     """
     v_frac = (T_loop - 0.9 * T_zoom) / (T_loop * T_zoom)
+    if v_frac < 0:
+        return 0.0  # Pas de scroll si la fenêtre couvre toute la boucle
     v_px_per_s = v_frac * canvas_width
     return v_px_per_s
+
+# Dans get_zoom_context(), le décalage appliqué à la fenêtre suit
+# exactement ce Δt_center :
+#    offset = progress * (T_loop - 0.9 * T_zoom)
+# On ignore tout décalage négatif éventuel.

--- a/player.py
+++ b/player.py
@@ -2413,9 +2413,17 @@ class VideoPlayer:
             loop_range = self.loop_end - self.loop_start
             progress = (playhead_ms - self.loop_start) / loop_range
             progress = max(0.0, min(1.0, progress))
-            offset = progress * (loop_range - base_zoom["zoom_range"])
+            # Correct direction: offset is based on the 5%-95% window movement
+            offset = progress * (loop_range - 0.9 * base_zoom["zoom_range"])
+            if offset < 0:
+                offset = 0
             zoom_dict["zoom_start"] = self.loop_start + offset
             zoom_dict["zoom_end"] = zoom_dict["zoom_start"] + base_zoom["zoom_range"]
+
+            # Re-clamp in case the dynamic offset pushes outside the video bounds
+            if zoom_dict["zoom_end"] > video_duration:
+                zoom_dict["zoom_end"] = video_duration
+                zoom_dict["zoom_start"] = max(0, video_duration - base_zoom["zoom_range"])
 
         return zoom_dict
 

--- a/test_player_utils.py
+++ b/test_player_utils.py
@@ -330,8 +330,8 @@ class TestZoomScroll(unittest.TestCase):
         d = self.Dummy()
         d.playhead_time = 5.0
         ctx = d.get_zoom_context()
-        self.assertEqual(ctx["zoom_start"], 2500)
-        self.assertEqual(ctx["zoom_end"], 7500)
+        self.assertEqual(ctx["zoom_start"], 2750)
+        self.assertEqual(ctx["zoom_end"], 7750)
 
 
 class TestTogglePauseLoopTiming(unittest.TestCase):
@@ -460,6 +460,27 @@ class TestComputeScrollSpeed(unittest.TestCase):
         from time_utils import compute_scroll_speed
         speed = compute_scroll_speed(10.0, 5.0, 1000)
         self.assertAlmostEqual(speed, 110.0)
+
+    def test_no_scroll_when_zoom_large(self):
+        from time_utils import compute_scroll_speed
+        # Zoom window larger than the loop should not yield negative speed
+        speed = compute_scroll_speed(10.0, 12.0, 1000)
+        self.assertEqual(speed, 0.0)
+
+
+class TestZoomContextDynamicScroll(unittest.TestCase):
+    def test_zoom_context_does_not_scroll_backwards(self):
+        vp = VideoPlayer.__new__(VideoPlayer)
+        vp.loop_start = 0
+        vp.loop_end = 1000
+        vp.loop_zoom_ratio = 1.0
+        vp.zoom_context = {"zoom_start": 0, "zoom_end": 1050, "zoom_range": 1050}
+        vp.playhead_time = 0.5
+        vp.player = MagicMock()
+        vp.player.get_length.return_value = 2000
+
+        zoom = VideoPlayer.get_zoom_context(vp)
+        self.assertGreater(zoom["zoom_start"], 0)
 
 
 if __name__ == '__main__':

--- a/time_utils.py
+++ b/time_utils.py
@@ -27,9 +27,22 @@ def format_time(seconds, include_ms=True, include_tenths=False):
 
 
 def compute_scroll_speed(T_loop, T_zoom, canvas_width):
-    """Return scroll speed (px/s) for static elements during dynamic zoom."""
+    """Return scroll speed (px/s) for static elements during dynamic zoom.
+
+    The speed should be positive when the zoom window is smaller than the loop
+    duration (dynamic scroll mode) and zero otherwise.  In particular when the
+    zoom range is wide enough that both A and B markers are visible, the scroll
+    speed must be ``0`` so elements remain static.
+    """
     if T_loop <= 0 or T_zoom <= 0 or canvas_width <= 0:
         return 0.0
+
     v_frac = (T_loop - 0.9 * T_zoom) / (T_loop * T_zoom)
+
+    # Clamp negative speed to 0 to avoid scrolling in the wrong direction when
+    # the zoom window is wider than the loop duration.
+    if v_frac < 0:
+        return 0.0
+
     return v_frac * canvas_width
 


### PR DESCRIPTION
## Summary
- handle negative values in `compute_scroll_speed`
- document the clamp in `AGENTS.md`
- test that scroll speed is zero when the zoom covers the whole loop
- fix dynamic scroll offset when zoom range is larger than the loop
- ensure zoom end is clamped to video duration
- add regression test to ensure no reverse scroll

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68459ad8b3ac832995124992e69728f0