### PR TITLE
Fix zoom ratio reset at high levels

### DIFF
--- a/player.py
+++ b/player.py
@@ -2046,6 +2046,12 @@ class VideoPlayer:
         if not self.loop_start or not self.loop_end:
             return
 
+        # When the user has intentionally chosen a high zoom ratio
+        # (>= 3x), we skip auto adjustments to avoid unwanted resets.
+        if getattr(self, "loop_zoom_ratio", 1.0) >= 3.0:
+            Brint("[ZOOM CHECK] ⏭️ High zoom ratio, skipping auto adjust")
+            return
+
         zoom = self.get_zoom_context()
         z_start = zoom["zoom_start"]
         z_end = zoom["zoom_end"]


### PR DESCRIPTION
## Summary
- stop auto zoom when loop_zoom_ratio is set to a very high value (>=3x)

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a29b28bc8329b82a8df59aeb750e