### PR TITLE
Update loop marker labels when out of view

### DIFF
--- a/player.py
+++ b/player.py
@@ -7255,13 +7255,19 @@ class VideoPlayer:
             xa = self.time_sec_to_canvas_x(self.loop_start / 1000)
             xa = max(0, min(xa, width))
             self.timeline.create_line(xa, 0, xa, 24, fill="green", tags="loop_marker")
-            self.timeline.create_text(xa + 10, 18, text=f"A: {self.hms(self.loop_start)}", anchor='w', fill="white", tags="loop_marker")
+            label = "A"
+            if zoom_start <= self.loop_start <= zoom_end:
+                label += f": {self.hms(self.loop_start)}"
+            self.timeline.create_text(xa + 10, 18, text=label, anchor='w', fill="white", tags="loop_marker")
 
         if self.loop_end:
             xb = self.time_sec_to_canvas_x(self.loop_end / 1000)
             xb = max(0, min(xb, width))
             self.timeline.create_line(xb, 0, xb, 24, fill="orange", tags="loop_marker")
-            self.timeline.create_text(xb + 10, 18, text=f"B: {self.hms(self.loop_end)}", anchor='w', fill="white", tags="loop_marker")
+            label = "B"
+            if zoom_start <= self.loop_end <= zoom_end:
+                label += f": {self.hms(self.loop_end)}"
+            self.timeline.create_text(xb + 10, 18, text=label, anchor='w', fill="white", tags="loop_marker")
 
         self.draw_audio_power_overlay()
 


### PR DESCRIPTION
## Summary
- show only `A` or `B` when loop markers fall outside of the zoom window

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ab2cf72c83299570eb8e7b908e5c