### PR TITLE
Fix clear_loop when no current_loop

### DIFF
--- a/player.py
+++ b/player.py
@@ -7930,7 +7930,8 @@ class VideoPlayer:
         if hasattr(self, "btn_edit_B"):
             self.btn_edit_B.config(relief="raised")
 
-        if hasattr(self, "current_loop"):
+        # Reset loop metadata if a current_loop is defined
+        if getattr(self, "current_loop", None) is not None:
             self.current_loop.loop_start = 0
             self.current_loop.loop_end = 0
 


### PR DESCRIPTION
## Summary
- avoid `AttributeError` in `clear_loop` when no loop is set

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845abdd0444832981776df9099cc621