### PR TITLE
Fix zoom centering when scrolling inactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,3 +155,5 @@ While this interpolated scroll is happening:
 	•	Scroll accordingly, so they stay aligned with the playhead’s real-time position.
 	•	Update dynamically to maintain visual accuracy and rhythmic alignment.
 
+### Troubleshooting Dynamic Scroll
+If you zoom to about **111%** of the loop length (zoom ratio around 0.9), the computed offset becomes very small. The playhead may appear fixed because the dynamic window shift is less than 1 ms and rounds to the loop start. To see the scroll effect, zoom in further so that the ratio drops noticeably below 0.9.

--- a/player.py
+++ b/player.py
@@ -2330,13 +2330,15 @@ class VideoPlayer:
         if base_zoom is not None:
             zoom_dict.update(base_zoom)
 
-        if (
+        dynamic_condition = (
             base_zoom is not None
             and self.loop_start is not None
             and self.loop_end is not None
             and base_zoom.get("zoom_range", 0) < (self.loop_end - self.loop_start) / 0.9
             and getattr(self, "playhead_time", None) is not None
-        ):
+        )
+
+        if dynamic_condition:
             playhead_ms = self.playhead_time * 1000.0
             loop_range = self.loop_end - self.loop_start
             progress = (playhead_ms - self.loop_start) / loop_range
@@ -2352,6 +2354,22 @@ class VideoPlayer:
             if zoom_dict["zoom_end"] > video_duration:
                 zoom_dict["zoom_end"] = video_duration
                 zoom_dict["zoom_start"] = max(0, video_duration - base_zoom["zoom_range"])
+        elif (
+            base_zoom is not None
+            and self.loop_start is not None
+            and self.loop_end is not None
+            and getattr(self, "playhead_time", None) is not None
+        ):
+            center_ms = (self.loop_start + self.loop_end) // 2
+            start = center_ms - base_zoom["zoom_range"] // 2
+            if start < 0:
+                start = 0
+            end = start + base_zoom["zoom_range"]
+            if end > video_duration:
+                end = video_duration
+                start = max(0, video_duration - base_zoom["zoom_range"])
+            zoom_dict["zoom_start"] = start
+            zoom_dict["zoom_end"] = end
 
         return zoom_dict
 

--- a/test_player_utils.py
+++ b/test_player_utils.py
@@ -482,6 +482,23 @@ class TestZoomContextDynamicScroll(unittest.TestCase):
         zoom = VideoPlayer.get_zoom_context(vp)
         self.assertGreater(zoom["zoom_start"], 0)
 
+class TestZoomContextCentering(unittest.TestCase):
+    def test_zoom_recenters_when_no_scroll(self):
+        vp = VideoPlayer.__new__(VideoPlayer)
+        vp.loop_start = 1000
+        vp.loop_end = 5000
+        vp.loop_zoom_ratio = 0.8
+        vp.zoom_context = {"zoom_start": 1000, "zoom_end": 6000, "zoom_range": 5000}
+        vp.playhead_time = 0.0
+        vp.player = MagicMock()
+        vp.player.get_length.return_value = 6000
+
+        zoom = VideoPlayer.get_zoom_context(vp)
+        expected_start = 3000 - 2500
+        expected_end = expected_start + 5000
+        self.assertEqual(zoom["zoom_start"], expected_start)
+        self.assertEqual(zoom["zoom_end"], expected_end)
+
 
 if __name__ == '__main__':
     unittest.main(argv=['first-arg-is-ignored'], exit=False)


### PR DESCRIPTION
## Summary
- center zoom window on the loop when scroll isn't active
- test zoom centering logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845a97c74b08329a6f3f20fee8de365