### PR TITLE
Fix dynamic zoom playhead positioning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ def compute_scroll_speed(T_loop, T_zoom, canvas_width):
     pendant que t_ph avance de t_A à t_B.
 
     Le centre de la fenêtre de zoom se déplace donc sur :
-        Δt_center = T_loop - 0.9 * T_zoom
+        Δt_center = T_loop - T_zoom
 
     → vitesse de scroll (fraction de canvas par seconde) :
         v_scroll = Δt_center / (T_loop * T_zoom)
@@ -44,7 +44,7 @@ def compute_scroll_speed(T_loop, T_zoom, canvas_width):
     → conversion en pixels :
         v_scroll_px = v_scroll * canvas_width
     """
-    v_frac = (T_loop - 0.9 * T_zoom) / (T_loop * T_zoom)
+    v_frac = (T_loop - T_zoom) / (T_loop * T_zoom)
     if v_frac < 0:
         return 0.0  # Pas de scroll si la fenêtre couvre toute la boucle
     v_px_per_s = v_frac * canvas_width
@@ -53,6 +53,6 @@ def compute_scroll_speed(T_loop, T_zoom, canvas_width):
 
 # Dans get_zoom_context(), le décalage appliqué à la fenêtre suit
 # exactement ce Δt_center :
-#    offset = progress * (T_loop - 0.9 * T_zoom)
+#    offset = progress * (T_loop - T_zoom)
 # On ignore tout décalage négatif éventuel.
 

--- a/player.py
+++ b/player.py
@@ -2089,11 +2089,10 @@ class VideoPlayer:
             
             if zoom_range >= loop_len:
                 # When the zoom window is wider than the loop, center the loop
-                # to keep A and B equidistant from the edges.
                 zoom_start = int(self.loop_start - (zoom_range - loop_len) / 2)
             else:
-                # Standard case: A at 5% and B at 95% of the visible range.
-                zoom_start = self.loop_start - int(0.05 * zoom_range)
+                # Dynamic scroll mode starts directly at A
+                zoom_start = self.loop_start
             zoom_end = zoom_start + zoom_range
 
             Brint(f"[AUTOZOOM] 📐 Calcul initial : zoom_start={zoom_start}, zoom_end={zoom_end}, zoom_range={zoom_range}")
@@ -2334,7 +2333,7 @@ class VideoPlayer:
             base_zoom is not None
             and self.loop_start is not None
             and self.loop_end is not None
-            and base_zoom.get("zoom_range", 0) < (self.loop_end - self.loop_start) / 0.9
+            and base_zoom.get("zoom_range", 0) < (self.loop_end - self.loop_start)
             and getattr(self, "playhead_time", None) is not None
         )
 
@@ -2343,9 +2342,8 @@ class VideoPlayer:
             loop_range = self.loop_end - self.loop_start
             progress = (playhead_ms - self.loop_start) / loop_range
             progress = max(0.0, min(1.0, progress))
-            # Correct direction: offset is based on the 5%-95% window movement
             base_range = base_zoom["zoom_range"]
-            offset = progress * (loop_range - 0.9 * base_range)
+            offset = progress * (loop_range - base_range)
             zoom_start = base_zoom.get("zoom_start", self.loop_start) + offset
             if zoom_start < 0:
                 zoom_start = 0

--- a/test_player_utils.py
+++ b/test_player_utils.py
@@ -330,8 +330,8 @@ class TestZoomScroll(unittest.TestCase):
         d = self.Dummy()
         d.playhead_time = 5.0
         ctx = d.get_zoom_context()
-        self.assertEqual(ctx["zoom_start"], 2750)
-        self.assertEqual(ctx["zoom_end"], 7750)
+        self.assertEqual(ctx["zoom_start"], 2500)
+        self.assertEqual(ctx["zoom_end"], 7500)
 
 
 class TestTogglePauseLoopTiming(unittest.TestCase):
@@ -459,7 +459,7 @@ class TestComputeScrollSpeed(unittest.TestCase):
     def test_basic_speed(self):
         from time_utils import compute_scroll_speed
         speed = compute_scroll_speed(10.0, 5.0, 1000)
-        self.assertAlmostEqual(speed, 110.0)
+        self.assertAlmostEqual(speed, 100.0)
 
     def test_no_scroll_when_zoom_large(self):
         from time_utils import compute_scroll_speed
@@ -480,7 +480,7 @@ class TestZoomContextDynamicScroll(unittest.TestCase):
         vp.player.get_length.return_value = 2000
 
         zoom = VideoPlayer.get_zoom_context(vp)
-        self.assertGreater(zoom["zoom_start"], 0)
+        self.assertGreaterEqual(zoom["zoom_start"], 0)
 
 class TestZoomContextCentering(unittest.TestCase):
     def test_zoom_recenters_when_no_scroll(self):

--- a/time_utils.py
+++ b/time_utils.py
@@ -37,7 +37,7 @@ def compute_scroll_speed(T_loop, T_zoom, canvas_width):
     if T_loop <= 0 or T_zoom <= 0 or canvas_width <= 0:
         return 0.0
 
-    v_frac = (T_loop - 0.9 * T_zoom) / (T_loop * T_zoom)
+    v_frac = (T_loop - T_zoom) / (T_loop * T_zoom)
 
     # Clamp negative speed to 0 to avoid scrolling in the wrong direction when
     # the zoom window is wider than the loop duration.


### PR DESCRIPTION
## Summary
- align compute_scroll_speed with corrected scroll distance
- keep zoom window anchored to marker A when in dynamic mode
- update zoom logic to shift by loop_range - zoom_range
- adjust unit tests for new behaviour
- document updated formulas in `AGENTS.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845cc7f08948329a4f50a4c39b416b1