### PR TITLE
Fix zoom position reset at loop start

### DIFF
--- a/player.py
+++ b/player.py
@@ -2330,6 +2330,17 @@ class VideoPlayer:
         if base_zoom is not None:
             zoom_dict.update(base_zoom)
 
+        if base_zoom is not None and getattr(self, "reset_zoom_next_frame", False):
+            start = base_zoom["zoom_start"]
+            end = start + base_zoom["zoom_range"]
+            if end > video_duration:
+                end = video_duration
+                start = max(0, video_duration - base_zoom["zoom_range"])
+            zoom_dict["zoom_start"] = start
+            zoom_dict["zoom_end"] = end
+            self.reset_zoom_next_frame = False
+            return zoom_dict
+
         dynamic_condition = (
             base_zoom is not None
             and self.loop_start is not None
@@ -3232,6 +3243,12 @@ class VideoPlayer:
             
     def safe_jump_to_time(self, target_ms, source="UNKNOWN"):
         Brint(f"[PH JUMP] 🚀 {source} → jump à {int(target_ms)} ms demandé")
+
+        if (
+            target_ms == getattr(self, "loop_start", None)
+            and str(source).startswith("Jump B")
+        ):
+            self.reset_zoom_next_frame = True
 
         self.player.set_time(int(target_ms))
         self.set_forced_jump(True, source=source)
@@ -6549,6 +6566,7 @@ class VideoPlayer:
         self.awaiting_vlc_jump = False
         self.freeze_interpolation = False
         self.last_seek_time = 0
+        self.reset_zoom_next_frame = False
 
 
 

--- a/test_player_utils.py
+++ b/test_player_utils.py
@@ -500,6 +500,24 @@ class TestZoomContextCentering(unittest.TestCase):
         self.assertEqual(zoom["zoom_end"], expected_end)
 
 
+class TestZoomResetAfterLoop(unittest.TestCase):
+    def test_reset_zoom_flag(self):
+        vp = VideoPlayer.__new__(VideoPlayer)
+        vp.loop_start = 0
+        vp.loop_end = 10000
+        vp.loop_zoom_ratio = 2.0
+        vp.zoom_context = {"zoom_start": 0, "zoom_end": 5000, "zoom_range": 5000}
+        vp.playhead_time = 5.0
+        vp.player = MagicMock()
+        vp.player.get_length.return_value = 15000
+        vp.reset_zoom_next_frame = True
+
+        zoom = VideoPlayer.get_zoom_context(vp)
+        self.assertEqual(zoom["zoom_start"], 0)
+        self.assertEqual(zoom["zoom_end"], 5000)
+        self.assertFalse(vp.reset_zoom_next_frame)
+
+
 class DummySlider:
     def __init__(self, max_idx):
         self.value = 0


### PR DESCRIPTION
## Summary
- keep a flag to reset dynamic zoom on next frame
- trigger flag when looping from B→A
- enforce zoom reset in `get_zoom_context`
- test zoom reset behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d4f909288329ad8b811a0b07f644