### PR TITLE
Fix zoom scroll calculations

### DIFF
--- a/player.py
+++ b/player.py
@@ -2354,9 +2354,10 @@ class VideoPlayer:
             loop_range = self.loop_end - self.loop_start
             progress = (playhead_ms - self.loop_start) / loop_range
             progress = max(0.0, min(1.0, progress))
-            # Correct direction: offset is based on the 5%-95% window movement
+            # Offset follows the loop progression so the playhead sweeps
+            # from 5% to 95% of the canvas
             base_range = base_zoom["zoom_range"]
-            offset = progress * (loop_range - 0.9 * base_range)
+            offset = progress * (loop_range - base_range)
             zoom_start = base_zoom.get("zoom_start", self.loop_start) + offset
             if zoom_start < 0:
                 zoom_start = 0
@@ -8454,7 +8455,7 @@ class VideoPlayer:
 
             
             loop_range = self.loop_end - self.loop_start
-            use_dynamic = zoom_range < loop_range / 0.9
+            use_dynamic = zoom_range < loop_range
             dynamic_factor = 0.90 if use_dynamic else 1.0
             pixels_per_beat = 1000 * interval_sec * canvas_width * dynamic_factor / zoom_range
 

--- a/test_player_utils.py
+++ b/test_player_utils.py
@@ -330,8 +330,8 @@ class TestZoomScroll(unittest.TestCase):
         d = self.Dummy()
         d.playhead_time = 5.0
         ctx = d.get_zoom_context()
-        self.assertEqual(ctx["zoom_start"], 2750)
-        self.assertEqual(ctx["zoom_end"], 7750)
+        self.assertEqual(ctx["zoom_start"], 2500)
+        self.assertEqual(ctx["zoom_end"], 7500)
 
 
 class TestTogglePauseLoopTiming(unittest.TestCase):
@@ -480,7 +480,10 @@ class TestZoomContextDynamicScroll(unittest.TestCase):
         vp.player.get_length.return_value = 2000
 
         zoom = VideoPlayer.get_zoom_context(vp)
-        self.assertGreater(zoom["zoom_start"], 0)
+        # With the playhead inside the loop, the zoom should not move
+        # backwards. It should clamp to the loop start when the
+        # computed offset would be negative.
+        self.assertEqual(zoom["zoom_start"], 0)
 
 class TestZoomContextCentering(unittest.TestCase):
     def test_zoom_recenters_when_no_scroll(self):


### PR DESCRIPTION
## Summary
- ensure dynamic scroll uses entire zoom range
- update zoom range logic for rhythm grid
- adjust tests for new zoom start behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845df6473188329b5ea8725a074d225