### PR TITLE
Optimize harmony overlay

### DIFF
--- a/player.py
+++ b/player.py
@@ -8849,7 +8849,6 @@ class VideoPlayer:
 
         
         canvas = self.harmony_canvas
-        canvas.delete("all")
         canvas_width = canvas.winfo_width()
         canvas_height = canvas.winfo_height()
 
@@ -8881,6 +8880,7 @@ class VideoPlayer:
         zoom_range = zoom["zoom_range"]
 
 
+
         Brint(f"[HARMONY DEBUG] zoom_start = {zoom_start:.1f} ms | zoom_end = {zoom_end:.1f} ms | zoom_range = {zoom_range:.1f} ms | canvas_width = {canvas_width}px")
 
         if canvas_width <= 10 or zoom_range <= 0:
@@ -8900,6 +8900,22 @@ class VideoPlayer:
         }
 
         display_mode = getattr(self, "harmony_chord_display_mode", "degree")
+
+        # --- Optimization: avoid heavy redraw when nothing changed ---
+        cache_key = (
+            int(zoom_start),
+            int(zoom_end),
+            display_mode,
+            getattr(self, "harmony_note_display_mode", "key"),
+            hash(str(chords)),
+            hash(str(getattr(self.current_loop, "mapped_notes", {}))),
+        )
+        if getattr(self, "_harmony_overlay_cache_key", None) == cache_key:
+            # No change in zoom or data → skip redraw
+            return
+        self._harmony_overlay_cache_key = cache_key
+
+        canvas.delete("all")
 
         Brint("[HARMONY] 🎼 Affichage harmonique basé sur loop.chords")
 


### PR DESCRIPTION
## Summary
- cache harmony overlay parameters and skip redraw if unchanged

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846071f85748329893d8aad9c2ffa5a