### PR TITLE
Fix playhead refresh when recording markers

### DIFF
--- a/player.py
+++ b/player.py
@@ -7250,7 +7250,7 @@ class VideoPlayer:
         else:
             current_time_ms = self.playhead_time * 1000
 
-        if not self.player.is_playing():
+        if forced_time_ms is None and not self.player.is_playing():
             return
 
         self.update_count += 1


### PR DESCRIPTION
## Summary
- keep playhead visible when updating time while paused

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68460a034f7883299008851d9da7f2de