### PR TITLE
Add hit offset feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ main shortcuts and what they do:
 | `*` | Increase bars in mode bar |
 | `/` | Decrease bars in mode bar |
 | `.` | Reset syllabic grid hits |
+| `[` / `]` | Shift all hit timestamps by ±1 subdivision |
 | `Shift+F1` | Cycle subdivision mode backward |
 | `Shift+F2` | Cycle subdivision mode forward |
 | `F4` | Toggle state window |

--- a/test_player_utils.py
+++ b/test_player_utils.py
@@ -581,6 +581,22 @@ class TestMatchHitsOrdering(unittest.TestCase):
         self.assertNotIn(0, hits)
 
 
+class TestOffsetHits(unittest.TestCase):
+    def test_offset_all_hit_timestamps(self):
+        vp = VideoPlayer.__new__(VideoPlayer)
+        vp.tempo_bpm = 120
+        vp.subdivision_mode = "binary8"
+        vp.get_subdivisions_per_beat = VideoPlayer.get_subdivisions_per_beat.__get__(vp)
+        vp.user_hit_timestamps = [(0.5, 0), (0.75, 1)]
+        vp.persistent_validated_hit_timestamps = {0.5}
+
+        VideoPlayer.offset_all_hit_timestamps(vp, 1)
+
+        interval = 60.0 / 120 / 2
+        self.assertAlmostEqual(vp.user_hit_timestamps[0][0], 0.5 + interval)
+        self.assertIn(0.5 + interval, vp.persistent_validated_hit_timestamps)
+
+
 if __name__ == '__main__':
     unittest.main(argv=['first-arg-is-ignored'], exit=False)
 


### PR DESCRIPTION
## Summary
- allow shifting all hit timestamps with new helper
- bind `[` and `]` keys to shift recorded hits by one subdivision
- document hit offset bindings in README
- test offset behaviour

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68467d2722c48329bae6f68cad1db8cb