### PR TITLE
Add confirmed hit context storage

### DIFF
--- a/player.py
+++ b/player.py
@@ -1432,7 +1432,9 @@ def loopdata_to_dict(loop_data):
         "master_note_list": loop_data.master_note_list if hasattr(loop_data, "master_note_list") else [],
         "chords": loop_data.chords if hasattr(loop_data, "chords") else [],
         "tempo_bpm": getattr(loop_data, "tempo_bpm", None),
-        "key": getattr(loop_data, "key", None)
+        "key": getattr(loop_data, "key", None),
+        "loop_zoom_ratio": getattr(loop_data, "loop_zoom_ratio", None),
+        "confirmed_hit_context": getattr(loop_data, "confirmed_hit_context", None),
     }
 
     Brint(f"[OK] Boucle prête : start={loop_dict['loop_start']}, end={loop_dict['loop_end']}, bpm={loop_dict['tempo_bpm']}")
@@ -1800,7 +1802,9 @@ class LoopData:
         
     #LOOPDATA INIT
 
-    def __init__(self, name, loop_start, loop_end, key=None, mode=None, chords=None, master_note_list=None, tempo_bpm=None,loop_zoom_ratio=None):
+    def __init__(self, name, loop_start, loop_end, key=None, mode=None,
+                 chords=None, master_note_list=None, tempo_bpm=None,
+                 loop_zoom_ratio=None, confirmed_hit_context=None):
         
         
         
@@ -1813,6 +1817,10 @@ class LoopData:
         self.master_note_list = master_note_list if master_note_list else []
         self.tempo_bpm = tempo_bpm  # ✅ Important
         self.loop_zoom_ratio = loop_zoom_ratio if loop_zoom_ratio is not None else .33
+        self.confirmed_hit_context = confirmed_hit_context or {
+            "timestamps": [],
+            "grid_mode": None
+        }
 
     @classmethod
     def from_dict(cls, data):
@@ -1831,10 +1839,12 @@ class LoopData:
             loop_end=data.get("loop_end"),
             key=data.get("key"),
             mode=data.get("mode"),
-            chords = normalized_chords ,
+            chords=normalized_chords,
             master_note_list=data.get("master_note_list", []),
-            tempo_bpm=data.get("tempo_bpm") or 60.0  # ✅ fallback à 60 bpm si None        
-            )
+            tempo_bpm=data.get("tempo_bpm") or 60.0,  # ✅ fallback à 60 bpm si None
+            loop_zoom_ratio=data.get("loop_zoom_ratio"),
+            confirmed_hit_context=data.get("confirmed_hit_context")
+        )
 
     def to_dict(self):
         Brint(f"[TO_DICT DEBUG] tempo_bpm exporté = {self.tempo_bpm}")
@@ -1847,7 +1857,9 @@ class LoopData:
             "mode": self.mode,
             "chords": self.chords,
             "master_note_list": self.master_note_list,
-            "tempo_bpm": self.tempo_bpm  # ✅ Ajouté ici
+            "tempo_bpm": self.tempo_bpm,  # ✅ Ajouté ici
+            "loop_zoom_ratio": self.loop_zoom_ratio,
+            "confirmed_hit_context": self.confirmed_hit_context
         }
         
         
@@ -2841,6 +2853,12 @@ class VideoPlayer:
         target_name = self.current_loop.name
         updated = False
 
+        # Synchronize confirmed hits context before exporting
+        self.current_loop.confirmed_hit_context = {
+            "timestamps": sorted(self.persistent_validated_hit_timestamps),
+            "grid_mode": self.subdivision_mode,
+        }
+
         for i, loop in enumerate(self.saved_loops):
             if loop["name"] == target_name:
                 Brint(f"[SAVE DEBUG] current_loop.tempo_bpm = {getattr(self.current_loop, 'tempo_bpm', '❌ None')}")
@@ -3218,6 +3236,15 @@ class VideoPlayer:
             return False, "Loop start ou end non numériques"
         if loop["loop_start"] >= loop["loop_end"]:
             return False, f"Loop start >= loop end ({loop['loop_start']} >= {loop['loop_end']})"
+
+        ctx = loop.get("confirmed_hit_context")
+        if ctx is not None:
+            if not isinstance(ctx, dict):
+                return False, "confirmed_hit_context invalide"
+            if "timestamps" in ctx and not isinstance(ctx["timestamps"], list):
+                return False, "timestamps doit être une liste"
+            if "grid_mode" in ctx and ctx["grid_mode"] is not None and not isinstance(ctx["grid_mode"], str):
+                return False, "grid_mode doit être une chaîne ou None"
         return True, None
 
     
@@ -3426,7 +3453,11 @@ class VideoPlayer:
             "tempo_bpm": self.current_loop.tempo_bpm,
             "key": self.current_loop.key,
             "mode": self.current_loop.mode,
-            "loop_zoom_ratio": getattr(self, "loop_zoom_ratio", None)  # ✅ new field
+            "loop_zoom_ratio": getattr(self, "loop_zoom_ratio", None),  # ✅ new field
+            "confirmed_hit_context": {
+                "timestamps": sorted(self.persistent_validated_hit_timestamps),
+                "grid_mode": self.subdivision_mode,
+            }
         }
 
         is_valid, reason = self.validate_loop_data(loop_data)
@@ -5905,6 +5936,14 @@ class VideoPlayer:
         self.loop_start = self.current_loop.loop_start
         self.loop_end = self.current_loop.loop_end
         self.auto_zoom_on_loop_markers(force=True)
+
+        # Restore confirmed hits context if present
+        ctx = loop.get("confirmed_hit_context", {})
+        timestamps = ctx.get("timestamps", [])
+        grid_mode = ctx.get("grid_mode")
+        self.persistent_validated_hit_timestamps = set(timestamps)
+        if grid_mode:
+            self.subdivision_mode = grid_mode
 
         if self.loop_start is None or self.loop_end is None:
             Brint("[ERROR] loop_start ou loop_end manquant après chargement")

--- a/test_player_utils.py
+++ b/test_player_utils.py
@@ -597,6 +597,30 @@ class TestOffsetHits(unittest.TestCase):
         self.assertIn(0.5 + interval, vp.persistent_validated_hit_timestamps)
 
 
+class TestConfirmedHitContext(unittest.TestCase):
+    def test_loopdata_round_trip(self):
+        ctx = {"timestamps": [0.5, 1.0], "grid_mode": "binary8"}
+        ld = player.LoopData("t", 0, 1000, tempo_bpm=60, loop_zoom_ratio=1.0,
+                             confirmed_hit_context=ctx)
+        d = ld.to_dict()
+        self.assertEqual(d["confirmed_hit_context"], ctx)
+
+        ld2 = player.LoopData.from_dict(d)
+        self.assertEqual(ld2.confirmed_hit_context, ctx)
+
+    def test_build_loop_data_includes_hits(self):
+        vp = VideoPlayer.__new__(VideoPlayer)
+        vp.current_loop = player.LoopData("t", 0, 1000, tempo_bpm=60)
+        vp.loop_start = 0
+        vp.loop_end = 1000
+        vp.loop_zoom_ratio = 1.0
+        vp.persistent_validated_hit_timestamps = {0.25, 0.5}
+        vp.subdivision_mode = "binary8"
+        data = VideoPlayer.build_loop_data(vp, "t")
+        self.assertEqual(sorted(data["confirmed_hit_context"]["timestamps"]), [0.25, 0.5])
+        self.assertEqual(data["confirmed_hit_context"]["grid_mode"], "binary8")
+
+
 if __name__ == '__main__':
     unittest.main(argv=['first-arg-is-ignored'], exit=False)
 


### PR DESCRIPTION
## Summary
- extend `LoopData` with `confirmed_hit_context`
- include hit context when building or saving loops
- restore hit context when loading saved loops
- expose loop zoom ratio and hit context in `LoopData.to_dict`
- test round trip and build loop data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846879f1ba48329819a65c62b0ee1b7