### PR TITLE
Fix missing grid_times on tempo change

### DIFF
--- a/player.py
+++ b/player.py
@@ -5141,6 +5141,11 @@ class VideoPlayer:
         self.build_rhythm_grid()
         self.draw_rhythm_grid_canvas()
         self.compute_rhythm_grid_infos()
+        # Ensure LoopData instance keeps its grid in sync with the player
+        if hasattr(self, "current_loop") and isinstance(self.current_loop, LoopData):
+            self.grid_subdivs = [(i, t) for i, t in enumerate(self.grid_times)]
+            self.current_loop.grid_times = self.grid_times
+            self.current_loop.grid_subdivs = self.grid_subdivs
 
         # Remap persistent validated hits to the new grid
         Brint("[REMAP_VALIDATED_HITS] Clearing old subdivision_state before remapping.")


### PR DESCRIPTION
## Summary
- sync LoopData `grid_times` when tempo changes
- keep `grid_subdivs` in sync when tempo grid is rebuilt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846892635f88329a3fa17f14ca164e8