### PR TITLE
Fix harmony overlay update when tempo changes

### DIFF
--- a/player.py
+++ b/player.py
@@ -9123,6 +9123,7 @@ class VideoPlayer:
             int(zoom_end),
             display_mode,
             getattr(self, "harmony_note_display_mode", "key"),
+            round(bpm, 4),  # include tempo to invalidate cache when feathering
             hash(str(chords)),
             hash(str(getattr(self.current_loop, "mapped_notes", {}))),
         )


### PR DESCRIPTION
## Summary
- include the current tempo in the harmony overlay cache key so chord rectangles and notes shift when feathering tempo

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68468a1a96748329a44784f578b4b99d