### PR TITLE
Adjust 64th jump in loops

### DIFF
--- a/player.py
+++ b/player.py
@@ -4189,6 +4189,8 @@ class VideoPlayer:
                 delta_ms = self.get_jump_duration_ms(level)
         else:
             delta_ms = self.get_jump_duration_ms(level)
+            if level == "64th":
+                delta_ms = int(delta_ms / 2)
 
         mode = self.edit_mode.get() if hasattr(self, "edit_mode") else None
 


### PR DESCRIPTION
## Summary
- halve the Alt+Ctrl+Shift jump duration when a loop is defined

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68468c76c61c8329a0c2d88031f48479