### PR TITLE
Fix persistent hit timestamps after adjusting loop markers

### DIFF
--- a/player.py
+++ b/player.py
@@ -7990,7 +7990,14 @@ class VideoPlayer:
         self.invalidate_jump_estimators()
         Brint("[RLM] ♻️ Cache precomputed_grid_infos invalidé à cause du déplacement de A ou B")
         self.precomputed_grid_infos = {}
-        self.compute_rhythm_grid_infos()  # 💡 À forcer sans reuse du cache
+
+        # Rebuild the rhythm grid to realign subdivisions with the new loop markers
+        self.build_rhythm_grid()
+        self.compute_rhythm_grid_infos()  # recompute using the fresh grid
+        self.remap_persistent_validated_hits()
+        if hasattr(self, "draw_rhythm_grid_canvas"):
+            self.draw_rhythm_grid_canvas()
+
         # self.draw_loop_markers()
         self.refresh_static_timeline_elements()
         Brint("[RLM] 🖍️ Redessin forcé des marqueurs après zoom")


### PR DESCRIPTION
## Summary
- update `record_loop_marker` to rebuild the rhythm grid
- recompute grid infos and remap persistent hits when A/B markers move

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684691ba43a083299ad989fbcf89b786