### PR TITLE
Fix zoom handling with inverted loop markers

### DIFF
--- a/player.py
+++ b/player.py
@@ -2303,6 +2303,11 @@ class VideoPlayer:
 
         loop_start = self.loop_start or 0
         loop_end = self.loop_end or self.duration or 10000  # fallback sécurité
+
+        # Handle inverted markers gracefully without altering instance values
+        if loop_end < loop_start:
+            loop_start, loop_end = loop_end, loop_start
+
         loop_width = loop_end - loop_start
         zoom_ratio = self.loop_zoom_ratio or 1.0
         zoom_width = int(loop_width / zoom_ratio)
@@ -2544,11 +2549,14 @@ class VideoPlayer:
         loop_start = self.loop_start or 0
         loop_end = self.loop_end or 0
 
-        if loop_end <= loop_start:
+        if loop_end < loop_start:
+            Brint(f"[WARN Time2X] Inverted markers A={self.loop_start} B={self.loop_end}")
+            loop_start, loop_end = loop_end, loop_start
+
+        if loop_end == loop_start:
             loop_start = 0
             loop_end = self.player.get_length()
-            self.loop_zoom_ratio = 1.0
-            Brint(f"[INFO Time2X] Pas de loop active, fallback à toute la durée ({loop_end} ms) avec zoom_ratio=1.0")
+            Brint(f"[INFO Time2X] Pas de loop active, fallback à toute la durée ({loop_end} ms)")
 
         loop_range = loop_end - loop_start
         zoom = self.get_zoom_context()

--- a/test_player_utils.py
+++ b/test_player_utils.py
@@ -518,6 +518,33 @@ class TestZoomResetAfterLoop(unittest.TestCase):
         self.assertFalse(vp.reset_zoom_next_frame)
 
 
+class TestInvertedLoopMarkers(unittest.TestCase):
+    def _create_player(self):
+        vp = VideoPlayer.__new__(VideoPlayer)
+        vp.loop_start = 8000
+        vp.loop_end = 2000
+        vp.loop_zoom_ratio = 2.0
+        vp.zoom_context = {"zoom_start": 0, "zoom_end": 5000, "zoom_range": 5000}
+        vp.playhead_time = 4.0
+        vp.player = MagicMock()
+        vp.player.get_length.return_value = 10000
+        vp.grid_canvas = MagicMock()
+        vp.grid_canvas.winfo_width.return_value = 1000
+        vp.cached_canvas_width = 1000
+        return vp
+
+    def test_get_zoom_context_handles_inversion(self):
+        vp = self._create_player()
+        zoom = VideoPlayer.get_zoom_context(vp)
+        self.assertLess(zoom["zoom_start"], zoom["zoom_end"])
+        self.assertEqual(vp.loop_zoom_ratio, 2.0)
+
+    def test_time_to_x_does_not_change_zoom_ratio(self):
+        vp = self._create_player()
+        VideoPlayer.time_sec_to_canvas_x(vp, 3.0)
+        self.assertEqual(vp.loop_zoom_ratio, 2.0)
+
+
 class DummySlider:
     def __init__(self, max_idx):
         self.value = 0


### PR DESCRIPTION
## Summary
- prevent zoom corruption when loop markers become inverted
- keep loop zoom ratio in `time_sec_to_canvas_x`
- test inverted marker behavior in `get_zoom_context` and `time_sec_to_canvas_x`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684699812f80832983f0d37c7a4e1dbc