### PR TITLE
Fix precomputed variable error

### DIFF
--- a/player.py
+++ b/player.py
@@ -9165,6 +9165,7 @@ class VideoPlayer:
         absolute_ms = int(current_time_ms + self.loop_pass_count * loop_dur_ms)
         self.record_user_hit(absolute_ms)
 
+        precomputed = self.precomputed_grid_infos or self.compute_rhythm_grid_infos()
         self.precomputed_grid_infos = precomputed
 
         # 1. Calcul de l'espacement moyen entre subdivisions


### PR DESCRIPTION
## Summary
- compute grid info when user hits to avoid undefined variable

## Testing
- `python ph_test.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847478d35208329b839cf0b9f54b9df