### PR TITLE
Fix subdivision state initialization

### DIFF
--- a/player.py
+++ b/player.py
@@ -3226,7 +3226,9 @@ class VideoPlayer:
         if hasattr(self, "confirmed_red_subdivisions"):
             self.confirmed_red_subdivisions.clear()
 
-        if hasattr(self, "subdivision_state"):
+        if not hasattr(self, "subdivision_state"):
+            self.subdivision_state = {}
+        else:
             self.subdivision_state.clear()
 
         if hasattr(self, "raw_hit_memory"):

--- a/zoomscrollref.py
+++ b/zoomscrollref.py
@@ -8625,9 +8625,9 @@ class VideoPlayer:
         x = self.precomputed_grid_infos[closest_i]["x"]
         Brint(f"[HIT VALIDATED] ✅ Subdiv {closest_i} ← hit à {current_time_sec:.3f}s | x={x:.1f}px | loop_pass={self.loop_pass_count}")
         # 🔴 Mise à jour immédiate du state = 2 pour affichage en rouge
-        if not hasattr(self, "subdivision_states"):
-            self.subdivision_states = {}
-        self.subdivision_states[closest_i] = 2
+        if not hasattr(self, "subdivision_state"):
+            self.subdivision_state = {}
+        self.subdivision_state[closest_i] = 2
         Brint(f"[HIT COLOR] 🔴 Subdiv {closest_i} marqué state=2 (rouge) immédiatement après frappe")
 
         self.draw_rhythm_grid_canvas()


### PR DESCRIPTION
## Summary
- initialize subdivision_state when resetting hits
- keep subdivision_state naming consistent when recording hits

## Testing
- `pytest -q` *(fails: TestInvertedLoopMarkers.test_time_to_x_does_not_change_zoom_ratio, TestZoomSliderButtons.test_increase_decrease)*

------
https://chatgpt.com/codex/tasks/task_e_6847700921c083298dbe9b939e3fe8f2