### PR TITLE
Fix red subdivision decay display

### DIFF
--- a/player.py
+++ b/player.py
@@ -3374,6 +3374,9 @@ class VideoPlayer:
                 self.subdivision_state[ridx] = 3
 
         for idx, hits in self.raw_hit_memory.items():
+            if self.subdivision_state.get(idx) == 3:
+                # Skip updates for persistent red subdivisions
+                continue
             valid_hits = [
                 (t, lp)
                 for (t, lp) in hits


### PR DESCRIPTION
## Summary
- stop updating state for confirmed red subdivisions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68482c6c2bb88329a3f0cd24419cb40d