### PR TITLE
Fix Brint timing to allow custom time provider

### DIFF
--- a/player.py
+++ b/player.py
@@ -11,7 +11,8 @@ import json
 import time
 from collections import defaultdict
 
-_real_perf_counter = time.perf_counter
+# Time provider used for Brint timing. Can be overridden for debugging.
+_brint_time_provider = time.perf_counter
 _last_brint_time = None
 
 
@@ -21,13 +22,20 @@ RECENT_FILES_PATH = os.path.join(os.path.dirname(__file__), "recent_files.json")
 def _print_with_time(*args, **kwargs):
     """Print message and show time since last Brint call."""
     global _last_brint_time
-    now = _real_perf_counter()
+    now = _brint_time_provider()
     if _last_brint_time is None:
         print(*args, **kwargs)
     else:
         delta = now - _last_brint_time
         print(f"[+{delta:.3f}s]", *args, **kwargs)
     _last_brint_time = now
+
+
+def set_brint_time_provider(provider):
+    """Override the time source used for Brint elapsed calculations."""
+    global _brint_time_provider
+    if callable(provider):
+        _brint_time_provider = provider
 
 import tempfile
 import atexit

--- a/zoomscrollref.py
+++ b/zoomscrollref.py
@@ -10,19 +10,27 @@ import re
 import json
 import time
 
-_real_perf_counter = time.perf_counter
+# Time provider used for Brint timing. Can be overridden for debugging.
+_brint_time_provider = time.perf_counter
 _last_brint_time = None
 
 def _print_with_time(*args, **kwargs):
     """Print message and show time since last Brint call."""
     global _last_brint_time
-    now = _real_perf_counter()
+    now = _brint_time_provider()
     if _last_brint_time is None:
         print(*args, **kwargs)
     else:
         delta = now - _last_brint_time
         print(f"[+{delta:.3f}s]", *args, **kwargs)
     _last_brint_time = now
+
+
+def set_brint_time_provider(provider):
+    """Override the time source used for Brint elapsed calculations."""
+    global _brint_time_provider
+    if callable(provider):
+        _brint_time_provider = provider
 
 import tempfile
 import ctypes


### PR DESCRIPTION
## Summary
- adjust Brint time logic to use a configurable provider
- add helper to set Brint timing source

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848540fc7388329aade6ee353b67050