### PR TITLE
Fix red subdivision persistence

### DIFF
--- a/player.py
+++ b/player.py
@@ -3878,8 +3878,8 @@ class VideoPlayer:
         getattr(self, "__raw_hit_memory_guard__", lambda: None)()
 
         
-        self.skip_old_state_restore = False  # reset pour les prochains appels
         skip_restore_old_states = getattr(self, "skip_old_state_restore", False)
+        self.skip_old_state_restore = False  # reset pour les prochains appels
         
         Brint(f"[CHECK NHIT USS] skip_restore_old_states = {skip_restore_old_states}")
 


### PR DESCRIPTION
## Summary
- keep `skip_old_state_restore` flag until after it is read

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849fb224b8c8329b22eda8372278493