### PR TITLE
Remove duplicate hms_to_seconds

### DIFF
--- a/player.py
+++ b/player.py
@@ -3051,9 +3051,6 @@ class VideoPlayer:
         except Exception as e:
             Brint(f"[WARNING] hms_from_seconds() → Impossible de convertir '{original_value}' en durée (s). Erreur: {e}")
             return "N/A"
-    def hms_to_seconds(hms):
-        parts = list(map(float, hms.split(":")))
-        return sum(t * 60**i for i, t in enumerate(reversed(parts)))
 
     def abph_stamp(self):
         """Return current A/B/playhead times in h:mm:ss.1 format."""


### PR DESCRIPTION
## Summary
- remove the unused `VideoPlayer.hms_to_seconds`
- rely on the global `hms_to_seconds` helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849fa854d0883299e765c94fa3f0473