### PR TITLE
Add NHIT debug on loop jump

### DIFF
--- a/player.py
+++ b/player.py
@@ -4454,6 +4454,8 @@ class VideoPlayer:
             
     def safe_jump_to_time(self, target_ms, source="UNKNOWN"):
         Brint(f"[PH JUMP] 🚀 {source} → jump à {int(target_ms)} ms demandé")
+        if "Jump B" in str(source):
+            Brint(f"[NHIT] {'🔁' * 15} Jump B→A | {self.abph_stamp()}")
 
         self.player.set_time(int(target_ms))
         self.set_forced_jump(True, source=source)


### PR DESCRIPTION
## Summary
- show an `[NHIT]` message with a clearer visual delimiter whenever playback jumps from B back to A

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a7004bec88329b3d3d8668c1a9007