### PR TITLE
Implement log separator on double Enter

### DIFF
--- a/player.py
+++ b/player.py
@@ -4327,6 +4327,12 @@ class VideoPlayer:
         
     def debug_keypress(self, event):
         Brint(f"[KEY DEBUG] keysym='{event.keysym}' | keycode={event.keycode} | char='{event.char}'")
+
+    def handle_double_enter(self, event=None):
+        """Print a decorative separator when Enter is pressed twice quickly."""
+        art = "\N{keyboard}" * 20
+        for _ in range(3):
+            print(art)
     #config player zoom
     
     
@@ -7753,6 +7759,7 @@ class VideoPlayer:
 
 
         self.root.bind_all("<Key>", self.debug_keypress)
+        self.root.bind_all("<Double-Return>", self.handle_double_enter)
 
 
         


### PR DESCRIPTION
## Summary
- add `handle_double_enter` method that prints a decorative keyboard pattern
- bind `<Double-Return>` to `handle_double_enter`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a9e40551083299030c4172090ec09