### PR TITLE
Add loop note playback toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ main shortcuts and what they do:
 | `b` | Edit loop end marker |
 | `Ctrl+Enter` | Reset playback speed |
 | `s` | Stop and return to A |
+| `n` | Toggle loop note playback |
 | `Shift+A` | Jump to marker A / record loop start |
 | `Shift+B` | Record loop end |
 | `Shift+C` | Clear current loop |


### PR DESCRIPTION
## Summary
- add `simpleaudio` import with fallback
- implement note frequency helper and note playback controls
- add `play_loop_notes` toggle bound to `n`
- update loop with note playback processing
- document new keyboard shortcut in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c62b749208329b0e4f3309cff1595