### PR TITLE
Deduplicate format_time helper

### DIFF
--- a/player.py
+++ b/player.py
@@ -21,6 +21,7 @@ from collections import defaultdict
 from datetime import timedelta
 from functools import partial
 from typing import Optional
+from time_utils import format_time
 
 # GUI
 import tkinter as tk
@@ -867,25 +868,6 @@ HOP_LENGTH = 256
 
 def seconds_to_hms(seconds):
     return str(timedelta(seconds=float(seconds))).split(".")[0]
-
-def format_time(seconds, include_ms=True, include_tenths=False):
-    """Format seconds as H:M:S with optional milliseconds or tenths."""
-    if seconds is None or seconds < 0:
-        if include_ms:
-            return "--:--:--.-" if include_tenths else "--:--:--.---"
-        return "--:--:--"
-
-    h = int(seconds // 3600)
-    m = int((seconds % 3600) // 60)
-    s = int(seconds % 60)
-
-    if include_ms:
-        if include_tenths:
-            tenths = int((seconds - int(seconds)) * 10)
-            return f"{h}:{m:02}:{s:02}.{tenths}"
-        ms = int(round((seconds - int(seconds)) * 1000))
-        return f"{h}:{m:02}:{s:02}.{ms:03}"
-    return f"{h}:{m:02}:{s:02}"
 
 def _util_extract_audio_segment(
     input_path,

--- a/test_player_utils.py
+++ b/test_player_utils.py
@@ -19,13 +19,13 @@ sys.modules['pydub'].AudioSegment = MagicMock()
 
 # Assuming player.py is in the same directory or accessible via PYTHONPATH
 from player import (
-    format_time,
     _util_extract_audio_segment,
     _util_get_tempo_and_beats_librosa,
     extract_keyframes,
     VideoPlayer,
     TraceableDict,
 )
+from time_utils import format_time
 import player
 
 class TestFormatTime(unittest.TestCase):


### PR DESCRIPTION
## Summary
- import `format_time` from `time_utils` in `player.py`
- reference `format_time` directly from `time_utils` in tests

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c7831de9c8329a724fe13f65d6fda