### PR TITLE
Configure MIDI loop port

### DIFF
--- a/player.py
+++ b/player.py
@@ -8846,6 +8846,7 @@ class VideoPlayer:
                 loop_start_ms=self.loop_start,
                 loop_end_ms=self.loop_end,
                 grid_times=self.grid_times,
+                port_name="Carla2Reaper",
             )
             if pattern:
                 self.midi_looper.load_pattern(pattern)


### PR DESCRIPTION
## Summary
- route MIDI loop playback to a dedicated Carla port

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d87b930708329bf1dbb57295e3b5f